### PR TITLE
- Fix : For Ios _setupClickNotify is required.

### DIFF
--- a/lib/services/firebase/firebase_push_helper.dart
+++ b/lib/services/firebase/firebase_push_helper.dart
@@ -26,9 +26,9 @@ class FirebasePushHelper extends FirebasePushHelperHelperProtocol {
     await messaging.requestPermission();
     _setupForegroundNotify();
     _setupBackGroundMessage();
+    _setupClickNotify();
 
     ///await _setupTerminatedNotify();
-    ///_setupClickNotify();
   }
 
   @override
@@ -41,8 +41,8 @@ class FirebasePushHelper extends FirebasePushHelperHelperProtocol {
 
   static void _setupBackGroundMessage() => FirebaseMessaging.onBackgroundMessage(_messageShowHandler);
 
-  /// void _setupClickNotify() => FirebaseMessaging.onMessageOpenedApp.listen((_) {});
-  ///
+  void _setupClickNotify() => FirebaseMessaging.onMessageOpenedApp.listen(_messageShowHandler);
+
   /// Future<void> _setupTerminatedNotify() async {
   ///   final initialMsg = await messaging.getInitialMessage();
   ///   if (initialMsg == null) return;


### PR DESCRIPTION
In IOS when we run app we need to use 

FirebaseMessaging.onMessageOpenedApp.listen(_messageShowHandler)

this firebase messaging method in order to open and navigating through the notification